### PR TITLE
Add unit tests for search feature

### DIFF
--- a/client/src/components/Form/SearchInput.test.js
+++ b/client/src/components/Form/SearchInput.test.js
@@ -1,0 +1,121 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import SearchInput from "./SearchInput";
+
+// Mock useSearch and useNavigate hooks
+jest.mock("../../context/search", () => ({
+  useSearch: jest.fn(),
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("axios");
+
+describe("SearchInput component", () => {
+  let mockSetValues;
+  let mockNavigate;
+
+  beforeEach(() => {
+    mockSetValues = jest.fn();
+    mockNavigate = jest.fn();
+
+    const mockValues = { keyword: "", results: [] };
+
+    require("../../context/search").useSearch.mockReturnValue([
+      mockValues,
+      mockSetValues,
+    ]);
+
+    require("react-router-dom").useNavigate.mockReturnValue(mockNavigate);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders search input and button", () => {
+    render(
+      <MemoryRouter>
+        <SearchInput />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByPlaceholderText("Search")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /search/i })).toBeInTheDocument();
+  });
+
+  test("updates input value when typing", () => {
+    render(
+      <MemoryRouter>
+        <SearchInput />
+      </MemoryRouter>
+    );
+
+    const input = screen.getByPlaceholderText("Search");
+    fireEvent.change(input, { target: { value: "wheelchair" } });
+
+    expect(mockSetValues).toHaveBeenCalledWith({ keyword: "wheelchair", results: [] });
+  });
+
+  test("submits form, calls API, updates results, and navigates", async () => {
+    const mockData = [{ id: 1, name: "Wheelchair Model A" }];
+
+    axios.get.mockResolvedValueOnce({ data: mockData });
+
+    const mockValues = { keyword: "wheelchair", results: [] };
+    require("../../context/search").useSearch.mockReturnValue([
+      mockValues,
+      mockSetValues,
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SearchInput />
+      </MemoryRouter>
+    );
+
+    const form = screen.getByRole("search");
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith("/api/v1/product/search/wheelchair");
+      expect(mockSetValues).toHaveBeenCalledWith({
+        ...mockValues,
+        results: mockData,
+      });
+      expect(mockNavigate).toHaveBeenCalledWith("/search");
+    });
+  });
+
+  test("handles API errors gracefully", async () => {
+    console.log = jest.fn(); // suppress console output
+
+    axios.get.mockRejectedValueOnce(new Error("Network error"));
+
+    const mockValues = { keyword: "test", results: [] };
+    require("../../context/search").useSearch.mockReturnValue([
+      mockValues,
+      mockSetValues,
+    ]);
+
+    render(
+      <MemoryRouter>
+        <SearchInput />
+      </MemoryRouter>
+    );
+
+    const form = screen.getByRole("search");
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith("/api/v1/product/search/test");
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error));
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/context/search.js
+++ b/client/src/context/search.js
@@ -1,4 +1,4 @@
-import { useState, useContext, createContext } from "react";
+import React, { useState, useContext, createContext } from "react";
 
 const SearchContext = createContext();
 const SearchProvider = ({ children }) => {
@@ -15,6 +15,12 @@ const SearchProvider = ({ children }) => {
 };
 
 // custom hook
-const useSearch = () => useContext(SearchContext);
+const useSearch = () => {
+  const context = useContext(SearchContext);
+  if (!context) {
+    throw new Error("useSearch must be used within a SearchProvider");
+  }
+  return context;
+};
 
 export { useSearch, SearchProvider };

--- a/client/src/context/search.test.js
+++ b/client/src/context/search.test.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { useSearch, SearchProvider } from "./search";
+
+// A simple test component that consumes the context
+const TestComponent = () => {
+  const [search, setSearch] = useSearch();
+
+  return (
+    <div>
+      <p data-testid="keyword">{search.keyword}</p>
+      <p data-testid="results">{JSON.stringify(search.results)}</p>
+      <button
+        onClick={() =>
+          setSearch({ keyword: "wheelchair", results: ["A", "B"] })
+        }
+      >
+        Update
+      </button>
+    </div>
+  );
+};
+
+describe("SearchContext and useSearch", () => {
+  test("provides default search state", () => {
+    render(
+      <SearchProvider>
+        <TestComponent />
+      </SearchProvider>
+    );
+
+    expect(screen.getByTestId("keyword").textContent).toBe("");
+    expect(screen.getByTestId("results").textContent).toBe("[]");
+  });
+
+  test("updates context state when setSearch is called", async () => {
+    render(
+      <SearchProvider>
+        <TestComponent />
+      </SearchProvider>
+    );
+
+    const button = screen.getByText("Update");
+
+    // ✅ Wrap state-changing action in act()
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(screen.getByTestId("keyword").textContent).toBe("wheelchair");
+    expect(screen.getByTestId("results").textContent).toBe(
+      JSON.stringify(["A", "B"])
+    );
+  });
+
+  test("throws error when useSearch is used outside of provider", () => {
+    const consoleError = console.error;
+    console.error = jest.fn();
+
+    const BadComponent = () => {
+      useSearch();
+      return <div />;
+    };
+
+    expect(() => render(<BadComponent />)).toThrow();
+
+    console.error = consoleError;
+  });
+});

--- a/client/src/pages/Search.test.js
+++ b/client/src/pages/Search.test.js
@@ -1,0 +1,73 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Search from "./Search";
+
+// Mock the Layout component to just render children
+jest.mock("./../components/Layout", () => ({ title, children }) => (
+  <div data-testid="layout">{children}</div>
+));
+
+// Mock the useSearch hook
+jest.mock("../context/search", () => ({
+  useSearch: jest.fn(),
+}));
+
+describe("Search Page", () => {
+  const mockUseSearch = require("../context/search").useSearch;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders 'No Products Found' when results are empty", () => {
+    mockUseSearch.mockReturnValue([{ keyword: "", results: [] }, jest.fn()]);
+
+    render(<Search />);
+
+    expect(screen.getByText("Search Resuts")).toBeInTheDocument();
+    expect(screen.getByText("No Products Found")).toBeInTheDocument();
+  });
+
+  test("renders product cards when results exist", () => {
+    const mockResults = [
+      {
+        _id: "1",
+        name: "Wheelchair A",
+        description: "Comfortable wheelchair for indoor use",
+        price: 100,
+      },
+      {
+        _id: "2",
+        name: "Wheelchair B",
+        description: "Lightweight folding wheelchair",
+        price: 150,
+      },
+    ];
+
+    mockUseSearch.mockReturnValue([{ keyword: "wheelchair", results: mockResults }, jest.fn()]);
+
+    render(<Search />);
+
+    // Heading shows correct number of results
+    expect(screen.getByText("Found 2")).toBeInTheDocument();
+
+    // Rendered product names
+    mockResults.forEach((p) => {
+      expect(screen.getByText(p.name)).toBeInTheDocument();
+      expect(screen.getByText(`${p.description.substring(0, 30)}...`)).toBeInTheDocument();
+        expect(screen.getByText((content) => content.includes(`$ ${p.price}`))).toBeInTheDocument();
+    });
+
+    // Buttons exist
+    expect(screen.getAllByText("More Details")).toHaveLength(2);
+    expect(screen.getAllByText("ADD TO CART")).toHaveLength(2);
+  });
+
+  test("renders correct heading inside Layout", () => {
+    mockUseSearch.mockReturnValue([{ keyword: "", results: [] }, jest.fn()]);
+
+    render(<Search />);
+
+    expect(screen.getByTestId("layout")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Testing scope:
- components/Form/SearchInput.js
- context/search.js
- pages/Search.js

Bugs Found:
- context/search.js: Custom hook useSearch() just returns undefined if called outside the provider.
   Fix: Update hook to throw an error when called outside the provider